### PR TITLE
docs: add Fronteir AI hosted deployment option

### DIFF
--- a/README.md
+++ b/README.md
@@ -309,3 +309,8 @@ This project is licensed under the MIT License License - see the [LICENSE](LICEN
 - [ ] Enhanced theme customization options
 - [ ] Component search and filtering
 - [ ] Real-time component preview generation
+
+## Hosted deployment
+
+A hosted deployment is available on [Fronteir AI](https://fronteir.ai/mcp/themesberg-flowbite-mcp).
+


### PR DESCRIPTION
Love the project!

Adds a short note in the README that a hosted deployment is available on [Fronteir AI](https://fronteir.ai/mcp/themesberg-flowbite-mcp)